### PR TITLE
runner.rb: make sure entire output is written to socket

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -183,17 +183,11 @@ require "socket"
 server = TCPServer.new("127.0.0.1", 15782)
 socket = server.accept
 
-PTY.open do |io, file|
-  pid = Process.spawn({"TERM" => "xterm"}, "/bin/bash", "--login", "/Users/travis/build.sh", [:out, :err] => file)
-  pipe_thread = Thread.new do
-    loop do
-      socket.print(io.read(1))
-    end
-  end
+PTY.spawn("/usr/bin/env", "TERM=xterm", "/bin/bash", "--login", "/Users/travis/build.sh") do |stdout, stdin, pid|
+  stdin.close
+  IO.copy_stream(stdout, socket)
 
   _, exit_status = Process.wait2(pid)
-  pipe_thread.kill
-
   File.open("/Users/travis/build.sh.exit", "w") { |f| f.print((exit_status.exitstatus || 127).to_s) }
 end
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -184,7 +184,6 @@ server = TCPServer.new("127.0.0.1", 15782)
 socket = server.accept
 
 PTY.spawn("/usr/bin/env", "TERM=xterm", "/bin/bash", "--login", "/Users/travis/build.sh") do |stdout, stdin, pid|
-  stdin.close
   IO.copy_stream(stdout, socket)
 
   _, exit_status = Process.wait2(pid)


### PR DESCRIPTION
The previous implementation would read and write a 1-byte buffer from the build.sh script to the socket, but the thread doing this is immediately closed once the process is finished. This makes it possible for some output not to have been read and written to the socket before the thread is closed, and we could lose some output at the end of a command.

The new implementation uses IO.copy_stream instead, which will copy the output from one IO object into another, and will block until the source object reaches an EOF. The current way of spawning the process with PTY.open and Process.spawn causes the "output" part of the pipe (the `io` variable) to not be closed at the end of the command, so that is changed to PTY.spawn, which does close the output IO object.
