### PR TITLE
Use systemsetup to automate some settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 matrix:
   include:
-    - osx_image: xcode8.1sneakpeek
+    - osx_image: xcode8.1
     - osx_image: xcode7.3
 
 script:

--- a/README.markdown
+++ b/README.markdown
@@ -44,10 +44,8 @@ out (for example OS X 10.9 to OS X 10.10).
 0. Don't register the Mac.
 0. Run necessary updates from `softwareupdate -l -a`. (You probably just want to
    do `softwareupdate -i -a`.)
-0. Enable "Remote Login" in the Sharing Preference Pane. This enables SSH.
 0. Run `xcode-select --install` and work through the dialog boxes that pop up
 0. Disable automatic updates in the App Store preference pane
-0. Disable every sleep option in the Energy Saver preference pane
 0. Make sure automatic login is enabled in the Users and Groups preference pane
    (under Login Options).
 0. Disable the Screen Saver

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,6 +24,14 @@ echo "node versions: $NODE_VERSIONS"
 echo "nvm version: $NVM_VERSION"
 
 bootstrap() {
+  echo "--- setting system preferences."
+  sudo systemsetup -settimezone GMT
+  sudo systemsetup -setsleep Off
+  sudo systemsetup -setcomputersleep Off
+  sudo systemsetup -setdisplaysleep Off
+  sudo systemsetup -setharddisksleep Off
+  sudo systemsetup -setremotelogin on
+
   echo "--- make .ssh/ && set permissions."
   mkdir -p ~/.ssh
   chmod 0700 ~/.ssh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -234,7 +234,7 @@ EOF
 </plist>
 EOF
   
-  launchctl load ~/Library/LaunchAgents/com.travis-ci.runner.plist
+  sudo launchctl load ~/Library/LaunchAgents/com.travis-ci.runner.plist
 
 
   echo "You may want to install the following:"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,6 +31,7 @@ bootstrap() {
   sudo systemsetup -setdisplaysleep Off
   sudo systemsetup -setharddisksleep Off
   sudo systemsetup -setremotelogin on
+  defaults write NSGlobalDomain NSAppSleepDisabled -bool YES
 
   echo "--- make .ssh/ && set permissions."
   mkdir -p ~/.ssh


### PR DESCRIPTION
This enforces the system sleep settings, as well as enabling remote login and setting the time zone. The relevant things have been removed from the README, since they now will be handled by the bootstrap script instead, with the exception of selecting the location, since that's a required step in the setup.